### PR TITLE
Fix for: Formatador.display_table [ {a: 1} ], [:missing]

### DIFF
--- a/lib/formatador/table.rb
+++ b/lib/formatador/table.rb
@@ -30,7 +30,7 @@ class Formatador
       split << '--+'
     else
       for header in headers
-        widths[header] ||= 0
+        widths[header] ||= header.to_s.length
         split << ('-' * (widths[header] + 2)) << '+'
       end
     end


### PR DESCRIPTION
Previously this would cause:

```
Formatador.display_table [ {a: 1} ], [:missing]
  +--+
ArgumentError: negative argument
    from /Users/gabebug/.rvm/gems/ruby-1.9.2-p180/gems/formatador-0.1.1/lib/formatador/table.rb:41:in `*'
    from /Users/gabebug/.rvm/gems/ruby-1.9.2-p180/gems/formatador-0.1.1/lib/formatador/table.rb:41:in `block in display_table'
    from /Users/gabebug/.rvm/gems/ruby-1.9.2-p180/gems/formatador-0.1.1/lib/formatador/table.rb:40:in `each'
    from /Users/gabebug/.rvm/gems/ruby-1.9.2-p180/gems/formatador-0.1.1/lib/formatador/table.rb:40:in `display_table'
    from (eval):3:in `display_table'
    from (irb):1:in `<top (required)>'
```

Fix displays as:

```
>> Formatador.display_table [ {a: 1} ], [:missing]
  +---------+
  | missing |
  +---------+
  |         |
  +---------+
```

Relevant for: https://github.com/geemus/fog/issues/221/
