### PR TITLE
Nicer table behavior?

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,6 +24,7 @@ You use tags, similar to html, to set formatting options:
 == Extensions
 
 * display_table: takes an array of hashes. Each hash is a row, with the keys being the headers and values being the data. An optional second argument can specify which headers/columns to include and in what order they should appear.
+* display_compact_table: Same as display_table, execpt that split lines are not drawn by default in the body of the table. If you need a split line, put a :split constant in the body array.
 * redisplay_progressbar: takes the current and total values as its first two arguments and redisplays a progressbar (until current = total and then it display_lines). An optional third argument represents the start time and will add an elapsed time counter.
 
 == Indentation

--- a/lib/formatador.rb
+++ b/lib/formatador.rb
@@ -103,7 +103,7 @@ class Formatador
     nil
   end
 
-  %w{display display_line display_lines display_table indent parse redisplay redisplay_progressbar}.each do |method|
+  %w{display display_line display_lines display_table display_compact_table indent parse redisplay redisplay_progressbar}.each do |method|
     eval <<-DEF
       def self.#{method}(*args, &block)
         Thread.current[:formatador] ||= new


### PR DESCRIPTION
I was playing with formatador tables and I noticed that they did the wrong thing if you tried to add some formatting in side a table cell.  Also, I would really like to draw tables with fewer separator bars. :)
- Changed the column width calculation to remove any formatador formatting codes.
- Added the ability to manually specify where to draw splits in the body of the table - with display_compact_table, and the use of the :split symbol in the data to be displayed.
