### PR TITLE
Bugfixes for progresspar

### DIFF
--- a/lib/formatador/progressbar.rb
+++ b/lib/formatador/progressbar.rb
@@ -24,18 +24,29 @@ class Formatador
       output << options[:label]
     end
 
-    padding = ' ' * (total.to_s.size - current.to_s.size)
-    output << "[#{color}]#{padding}#{current}/#{total}[/]"
+    # width
+    # we are going to write a string that looks like "   current/total"
+    # It would be nice if it were left padded with spaces in such a way that
+    # it puts the progress bar in a constant place on the page. This witdh
+    # calculation allows for the "current" string to be up to two characters
+    # longer than the "total" string without problems. eg- current =
+    # 9.99, total = 10
+    padding = total.to_s.size * 2 + 3
+    
+    output << "[#{color}]%#{padding}s[/]" % "#{current}/#{total}"
 
     percent = current.to_f / total.to_f
+    percent = 0 if percent < 0
+    percent = 1 if percent > 1
+
     done = '*' * (percent * width).ceil
     remaining = ' ' * (width - done.length)
     output << "[_white_]|[/][#{color}][_#{color}_]#{done}[/]#{remaining}[_white_]|[/]"
 
     if started_at
       elapsed = Time.now - started_at
-      minutes = (elapsed / 60).round.to_s
-      seconds = (elapsed % 60).round.to_s
+      minutes = (elapsed / 60).truncate.to_s
+      seconds = (elapsed % 60).truncate.to_s
       output << "#{minutes}:#{'0' if seconds.size < 2}#{seconds}"
     end
 


### PR DESCRIPTION
Fixed a bug in the time-display where the time would jump from 0:29 to 1:30, and then again from 1:59 to 1:00.

Fixed a couple of places where out-of-expected-domain inputs could cause redisplay_progressbar to multiply a string by a negative number.
