### PR TITLE
Add require 'stringio'

### DIFF
--- a/tests/tests_helper.rb
+++ b/tests/tests_helper.rb
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'formatador'
 require 'rubygems'
 require 'shindo'
+require 'stringio'
 
 def capture_stdout
   old_stdout = $stdout


### PR DESCRIPTION
Require 'stringio' in tests_helper to be able to run tests only with shindo
