### PR TITLE
Pass correct width to redisplay from redisplay_progressbar

### DIFF
--- a/lib/formatador/progressbar.rb
+++ b/lib/formatador/progressbar.rb
@@ -4,9 +4,9 @@ class Formatador
     options = { :color => 'white', :width => 50, :new_line => true }.merge!(options)
     data = progressbar(current, total, options)
     if current < total
-      redisplay(data)
+      redisplay(data, options[:width])
     else
-      redisplay("#{data}")
+      redisplay("#{data}", options[:width])
       if options[:new_line]
         new_line
       end


### PR DESCRIPTION
The width is established, but not passed along. This causes unnecessary scrolling on small terminals.
