### PR TITLE
Incorrect homepage in gem metadata

### DIFF
--- a/formatador.gemspec
+++ b/formatador.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   ## a custom homepage, consider using your GitHub URL or the like.
   s.authors  = ["geemus (Wesley Beary)"]
   s.email    = 'geemus@gmail.com'
-  s.homepage = 'http://github.com/geemus/NAME'
+  s.homepage = "http://github.com/geemus/#{s.name}"
 
   ## This gets added to the $LOAD_PATH so that 'lib/NAME.rb' can be required as
   ## require 'NAME.rb' or'/lib/NAME/file.rb' can be as require 'NAME/file.rb'


### PR DESCRIPTION
In `formatador.gemspec`, [line 30](https://github.com/geemus/formatador/blob/master/formatador.gemspec#L30) ends in `NAME`, that was probably meant to be:

```
  s.homepage = "http://github.com/geemus/#{s.name}"
```
