### PR TITLE
Found a bug in the implementation of the nested hash

### DIFF
--- a/lib/formatador/table.rb
+++ b/lib/formatador/table.rb
@@ -84,7 +84,7 @@ class Formatador
   end
 
   def calculate_datum(header, hash)
-    if (splits = header.to_s.split('.')).length > 1
+    if !hash.keys.include?(header) && (splits = header.to_s.split('.')).length > 1
       datum = nil
       splits.each do |split|
         d = (datum||hash)

--- a/tests/table_tests.rb
+++ b/tests/table_tests.rb
@@ -78,4 +78,19 @@ output = Formatador.parse(output)
     end
   end
 
+output = <<-OUTPUT
+    +---+--------------+
+    | [bold]a[/] | [bold]just.pointed[/] |
+    +---+--------------+
+    | 1 | value        |
+    +---+--------------+
+OUTPUT
+output = Formatador.parse(output)
+
+  tests("#display_table([{:a => 1, 'just.pointed' => :value}])").returns(output) do
+    capture_stdout do
+      Formatador.display_table([{:a => 1, 'just.pointed' => :value}])
+    end
+  end
+
 end


### PR DESCRIPTION
I found a bug in the implementation of the nested hash:

I discovered this when I used fog and asked for spot_requests which has a header of "LaunchSpecification.GroupSet". That caused formatador to bomb out, obviously, because it was expecting that to be a hash.

This should fix it. Also added test case.
