### PR TITLE
Use $stdout instead of STDOUT

### DIFF
--- a/lib/formatador.rb
+++ b/lib/formatador.rb
@@ -62,7 +62,7 @@ class Formatador
 
   def display(string = '')
     print(parse("[indent]#{string}"))
-    STDOUT.flush
+    $stdout.flush
     nil
   end
 
@@ -80,7 +80,7 @@ class Formatador
   end
 
   def parse(string)
-    if STDOUT.tty?
+    if $stdout.tty?
       string.gsub(PARSE_REGEX) { "\e[#{STYLES[$1.to_sym]}m" }.gsub(INDENT_REGEX) { indentation }
     else
       strip(string)

--- a/tests/tests_helper.rb
+++ b/tests/tests_helper.rb
@@ -5,9 +5,15 @@ require 'rubygems'
 require 'shindo'
 require 'stringio'
 
+class TTYStringIO < StringIO
+  def tty?
+    true
+  end
+end
+
 def capture_stdout
   old_stdout = $stdout
-  new_stdout = StringIO.new
+  new_stdout = TTYStringIO.new
   $stdout = new_stdout
   yield
   $stdout = old_stdout


### PR DESCRIPTION
Currently `parse` uses `STDOUT` to check if the output is going a terminal.
However, the actual output `$stdout` may have been reassigned. This is just a
simple change to use `$stdout` instead with a hack to make tests continue to
work.
