### PR TITLE
Support multibyte charcters

### DIFF
--- a/lib/formatador/table.rb
+++ b/lib/formatador/table.rb
@@ -83,11 +83,11 @@ class Formatador
     if Module.const_defined?(:Unicode)
       Unicode.width(value.to_s.gsub(PARSE_REGEX, ''))
     else
-      value.to_s.gsub(PARSE_REGEX, '').length
+      value.to_s.gsub(PARSE_REGEX, '').chars.reduce(0) { |sum, char| sum += char.bytesize > 1 ? 2 : 1 }
     end
 
   rescue NotImplementedError
-    value.to_s.gsub(PARSE_REGEX, '').length
+    value.to_s.gsub(PARSE_REGEX, '').chars.reduce(0) { |sum, char| sum += char.bytesize > 1 ? 2 : 1 }
   end
 
   def calculate_datum(header, hash)

--- a/tests/table_tests.rb
+++ b/tests/table_tests.rb
@@ -95,7 +95,6 @@ output = Formatador.parse(output)
   end
 
 
-  if Module.const_defined?(:Unicode)
 output = <<-OUTPUT
     +------+
     | [bold]a[/]    |
@@ -107,10 +106,9 @@ output = <<-OUTPUT
 OUTPUT
   output = Formatador.parse(output)
 
-    tests("#display_table([{:a => 1}, {:a => 2}])").returns(output) do
-      capture_stdout do
-        Formatador.display_table([{:a => 1}, {:a => "震度"}])
-      end
+  tests("#display_table([{:a => 1}, {:a => 2}])").returns(output) do
+    capture_stdout do
+      Formatador.display_table([{:a => 1}, {:a => "震度"}])
     end
   end
 


### PR DESCRIPTION
Hi ! @geemus 😀 
I use this gem in Japan.

When I try to display multibyte characters, the format of table is broken.
So, I fix a logic that calculate table width.

#26 fix this problem to use `Unicode` module.
But this PR fix it without any gem dependencies.

Example.
```
# Before
> Formatador.display_table([{:a => 1}, {:a => "震度"}])
  +----+
  | a  |
  +----+
  | 1  |
  +----+
  | 震度 |
  +----+

# After
> Formatador.display_table([{:a => 1}, {:a => "震度"}])
  +------+
  | a    |
  +------+
  | 1    |
  +------+
  | 震度 |
  +------+
```