### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,10 +21,6 @@ def date
   Date.today.to_s
 end
 
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "#{name}.gemspec"
 end
@@ -111,8 +107,6 @@ task :gemspec => :validate do
   replace_header(head, :name)
   replace_header(head, :version)
   replace_header(head, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(head, :rubyforge_project)
 
   # determine file list from git ls-files
   files = `git ls-files`.

--- a/formatador.gemspec
+++ b/formatador.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.name              = 'formatador'
   s.version           = '0.2.5'
   s.date              = '2014-05-23'
-  s.rubyforge_project = 'formatador'
 
   ## Make sure your summary is short. The description may be as long
   ## as you like.


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.