### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/formatador.gemspec
+++ b/formatador.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   ## a custom homepage, consider using your GitHub URL or the like.
   s.authors  = ["geemus (Wesley Beary)"]
   s.email    = 'geemus@gmail.com'
-  s.homepage = "http://github.com/geemus/#{s.name}"
+  s.homepage = "https://github.com/geemus/#{s.name}"
   s.license  = 'MIT'
 
   ## This gets added to the $LOAD_PATH so that 'lib/NAME.rb' can be required as


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/formatador or some tools or APIs that use the gem's metadata.