### PR TITLE
Modified README.rdoc to README.md in gemspec.

### DIFF
--- a/formatador.gemspec
+++ b/formatador.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   ## Specify any RDoc options here. You'll want to add your README and
   ## LICENSE files to the extra_rdoc_files list.
   s.rdoc_options = ["--charset=UTF-8"]
-  s.extra_rdoc_files = %w[README.rdoc]
+  s.extra_rdoc_files = %w[README.md]
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
     CONTRIBUTORS.md
     Gemfile
     LICENSE.md
-    README.rdoc
+    README.md
     Rakefile
     changelog.txt
     formatador.gemspec


### PR DESCRIPTION
I got `["README.rdoc"] are not files` error when run `rake build`.

<details>
    <summary>Reproduction procedure</summary>

```
$ docker run -it --rm -v "$(pwd):/formatador" --workdir "/formatador" ruby:2.7 bash
root@d6cc0ee883a9:/formatador# bundle install
Fetching gem metadata from http://rubygems.org/.......
Fetching rake 13.0.3
Installing rake 13.0.3
Using bundler 2.1.4
Using formatador 0.2.5 from source at `.`
Fetching rdoc 6.3.0
Installing rdoc 6.3.0
Fetching shindo 0.3.9
Installing shindo 0.3.9
Bundle complete! 4 Gemfile dependencies, 5 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
root@d6cc0ee883a9:/formatador# bundle exec rake build
Updated formatador.gemspec
mkdir -p pkg
gem build formatador.gemspec
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["README.rdoc"] are not files
rake aborted!
Command failed with status (1): [gem build formatador.gemspec...]
/formatador/rakefile:97:in `block in <top (required)>'
/usr/local/bundle/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
/usr/local/bin/bundle:23:in `load'
/usr/local/bin/bundle:23:in `<main>'
Tasks: TOP => build
(See full trace by running task with --trace)
```

</details>

I seem this cause is that moved README to md in 4c7044375fdc3ee034031ea7d214cf1485cd143e, but [no fixed `extra_rdoc_files` in gemspec](https://github.com/geemus/formatador/blob/master/formatador.gemspec#L47).
