### PR TITLE
Add options of right-justify a numeric

### DIFF
--- a/lib/formatador.rb
+++ b/lib/formatador.rb
@@ -121,9 +121,9 @@ class Formatador
 
   %w{display display_line display_lines display_table display_compact_table indent parse redisplay redisplay_line new_line redisplay_progressbar}.each do |method|
     eval <<-DEF
-      def self.#{method}(*args, &block)
+      def self.#{method}(*args, **kwargs, &block)
         Thread.current[:formatador] ||= new
-        Thread.current[:formatador].#{method}(*args, &block)
+        Thread.current[:formatador].#{method}(*args, **kwargs, &block)
       end
     DEF
   end

--- a/lib/formatador.rb
+++ b/lib/formatador.rb
@@ -119,7 +119,16 @@ class Formatador
     string.gsub(PARSE_REGEX, '').gsub(INDENT_REGEX) { indentation }
   end
 
-  %w{display display_line display_lines display_table display_compact_table indent parse redisplay redisplay_line new_line redisplay_progressbar}.each do |method|
+  %w{display display_line display_lines indent parse redisplay redisplay_line new_line redisplay_progressbar}.each do |method|
+    eval <<-DEF
+      def self.#{method}(*args, &block)
+        Thread.current[:formatador] ||= new
+        Thread.current[:formatador].#{method}(*args, &block)
+      end
+    DEF
+  end
+
+  %w{display_table display_compact_table}.each do |method|
     eval <<-DEF
       def self.#{method}(*args, **kwargs, &block)
         Thread.current[:formatador] ||= new

--- a/lib/formatador/table.rb
+++ b/lib/formatador/table.rb
@@ -1,13 +1,13 @@
 class Formatador
-  def display_table(hashes, keys = nil, &block)
+  def display_table(hashes, keys = nil, numeric_rjust: false, &block)
     new_hashes = hashes.inject([]) do |accum,item|
       accum << :split unless accum.empty?
       accum << item
     end
-    display_compact_table(new_hashes, keys, &block)
+    display_compact_table(new_hashes, keys, numeric_rjust: numeric_rjust, &block)
   end
 
-  def display_compact_table(hashes, keys = nil, &block)
+  def display_compact_table(hashes, keys = nil, numeric_rjust: false, &block)
     headers = keys || []
     widths = {}
 
@@ -59,12 +59,12 @@ class Formatador
 
     hashes.each do |hash|
       if hash.respond_to? :keys
-        columns = []
-        headers.each do |header|
+        columns = headers.map do |header|
           datum = calculate_datum(header, hash)
           width = widths[header] - length(datum)
           width = width < 0 ? 0 : width
-          columns << "#{datum}#{' ' * width}"
+
+          datum.is_a?(Numeric) && numeric_rjust ? "#{' ' * width}#{datum}" : "#{datum}#{' ' * width}"
         end
         display_line("| #{columns.join(' | ')} |")
       else

--- a/lib/formatador/table.rb
+++ b/lib/formatador/table.rb
@@ -1,13 +1,13 @@
 class Formatador
-  def display_table(hashes, keys = nil, numeric_rjust: false, &block)
+  def display_table(hashes, keys = nil, **options, &block)
     new_hashes = hashes.inject([]) do |accum,item|
       accum << :split unless accum.empty?
       accum << item
     end
-    display_compact_table(new_hashes, keys, numeric_rjust: numeric_rjust, &block)
+    display_compact_table(new_hashes, keys, **options, &block)
   end
 
-  def display_compact_table(hashes, keys = nil, numeric_rjust: false, &block)
+  def display_compact_table(hashes, keys = nil, **options, &block)
     headers = keys || []
     widths = {}
 
@@ -64,7 +64,7 @@ class Formatador
           width = widths[header] - length(datum)
           width = width < 0 ? 0 : width
 
-          datum.is_a?(Numeric) && numeric_rjust ? "#{' ' * width}#{datum}" : "#{datum}#{' ' * width}"
+          datum.is_a?(Numeric) && options[:numeric_rjust] ? "#{' ' * width}#{datum}" : "#{datum}#{' ' * width}"
         end
         display_line("| #{columns.join(' | ')} |")
       else

--- a/tests/table_tests.rb
+++ b/tests/table_tests.rb
@@ -109,6 +109,21 @@ output = Formatador.parse(output)
     end
   end
 
+output = <<-OUTPUT
+    +--------+------------+
+    | [bold]header[/] | [bold]nested.key[/] |
+    +--------+------------+
+    |  12345 | value      |
+    +--------+------------+
+OUTPUT
+output = Formatador.parse(output)
+
+  tests("#display_table([{:header => 12345, :nested => {:key => value}}], [:header, :'nested.key'], numeric_rjust: true)").returns(output) do
+    capture_stdout do
+      Formatador.display_table([{:header => 12345, :nested => {:key => 'value'}}], [:header, :'nested.key'], numeric_rjust: true)
+    end
+  end
+
 
 output = <<-OUTPUT
     +------+

--- a/tests/table_tests.rb
+++ b/tests/table_tests.rb
@@ -94,6 +94,21 @@ output = Formatador.parse(output)
     end
   end
 
+output = <<-OUTPUT
+    +-------------------------+----------------+
+    | [bold]right-justify a numeric[/] | [bold]standard value[/] |
+    +-------------------------+----------------+
+    |                   12345 | value          |
+    +-------------------------+----------------+
+OUTPUT
+output = Formatador.parse(output)
+
+  tests("#display_table([{'right-justify a numeric' => 12345, 'standard value' => 'standard value'}], numeric_rjust: true)").returns(output) do
+    capture_stdout do
+      Formatador.display_table([{'right-justify a numeric' => 12345, 'standard value' => 'value'}], numeric_rjust: true)
+    end
+  end
+
 
 output = <<-OUTPUT
     +------+


### PR DESCRIPTION
related issue: #38

Added `numeric_rjust` option to right-justify numeric.

example:
```
# before
Formatador.display_table([{'right-justify a numeric' => 12345, 'standard value' => 'value'}])
  +-------------------------+----------------+
  | right-justify a numeric | standard value |
  +-------------------------+----------------+
  | 12345                   | value          |
  +-------------------------+----------------+


# after
> Formatador.display_table([{'right-justify a numeric' => 12345, 'standard value' => 'value'}], numeric_rjust: true)
  +-------------------------+----------------+
  | right-justify a numeric | standard value |
  +-------------------------+----------------+
  |                   12345 | value          |
  +-------------------------+----------------+
```