### PR TITLE
Gemfile: use https to contact RubyGems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec


### PR DESCRIPTION
This PR changes to use the conventional HTTPS.